### PR TITLE
Real-time implementation using ForceTorqueSensorInterface and ForceTorqueSensorController

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,27 @@
 This is the driver for the ATI NET/FT box that is used to connect to ATI F/T sensor. This repo is ported from https://code.ros.org/svn/wg-ros-pkg/stacks/netft/trunk. 
 It has been catkinized and updated for ROS Indigo. This ROS driver only supports communciation with the NET/FT device using the Raw Data Transfer (RDT) protocol (using UDP packets) over Ethernet. The NET/FT box can also be interfaced using Ethernet/IP or CAN but these modes are not supported by the ROS driver. 
 
-Usage
------
+## Usage
 
 Use the ROS node in the package as a stand-alone node for publishing F/T information. E.g.:
-```rosrun netft_rdt_driver netft_node --address 192.168.1.1```
+
+```
+rosrun netft_rdt_driver netft_node --address 192.168.1.1
+``` 
 
 The NET/FT box defaults to 192.168.1.1 as its ip address but this can be changed using the browser-based interface.
 
 See a more detailed tutorial here: http://wiki.ros.org/netft_rdt_driver/Tutorials/RunningNetFTNode
+
+### Real-Time Hardware Interface
+
+For applications that require to read from the netft in real-time, there is an implementation that uses a `hardware_interface::ForceTorqueSensorInterface` and a `force_torque_sensor_controller::ForceTorqueSensorController` from `ros_control` along side with OROCOS to achieve such behaviour.
+
+This implementation is based in this [rtt_ros_control_example](https://github.com/skohlbr/rtt_ros_control_example).
+
+There is a convenient launch file:
+```
+roslaunch netft_rdt_driver netft_rrt_controller.launch ip_address:=192.168.1.1
+``` 
+
+For more insights regarding this implementation please read this [useful discussion](https://github.com/ros-controls/ros_control/issues/130).

--- a/netft_rdt_driver/CMakeLists.txt
+++ b/netft_rdt_driver/CMakeLists.txt
@@ -1,133 +1,54 @@
 cmake_minimum_required(VERSION 2.8.3)
 project(netft_rdt_driver)
 
-## Find catkin macros and libraries
-## if COMPONENTS list like find_package(catkin REQUIRED COMPONENTS xyz)
-## is used, also find other catkin packages
 find_package(catkin REQUIRED COMPONENTS
+  controller_manager
   diagnostic_msgs
   diagnostic_updater
+  force_torque_sensor_controller
   geometry_msgs
+  hardware_interface
   roscpp
+  rtt_ros
+  rtt_rosclock
 )
 
-## System dependencies are found with CMake's conventions
 find_package(Boost REQUIRED COMPONENTS system thread program_options)
 
 
-## Uncomment this if the package has a setup.py. This macro ensures
-## modules and global scripts declared therein get installed
-## See http://ros.org/doc/api/catkin/html/user_guide/setup_dot_py.html
-# catkin_python_setup()
 
-################################################
-## Declare ROS messages, services and actions ##
-################################################
-
-## To declare and build messages, services or actions from within this
-## package, follow these steps:
-## * Let MSG_DEP_SET be the set of packages whose message types you use in
-##   your messages/services/actions (e.g. std_msgs, actionlib_msgs, ...).
-## * In the file package.xml:
-##   * add a build_depend and a run_depend tag for each package in MSG_DEP_SET
-##   * If MSG_DEP_SET isn't empty the following dependencies might have been
-##     pulled in transitively but can be declared for certainty nonetheless:
-##     * add a build_depend tag for "message_generation"
-##     * add a run_depend tag for "message_runtime"
-## * In this file (CMakeLists.txt):
-##   * add "message_generation" and every package in MSG_DEP_SET to
-##     find_package(catkin REQUIRED COMPONENTS ...)
-##   * add "message_runtime" and every package in MSG_DEP_SET to
-##     catkin_package(CATKIN_DEPENDS ...)
-##   * uncomment the add_*_files sections below as needed
-##     and list every .msg/.srv/.action file to be processed
-##   * uncomment the generate_messages entry below
-##   * add every package in MSG_DEP_SET to generate_messages(DEPENDENCIES ...)
-
-## Generate messages in the 'msg' folder
-# add_message_files(
-#   FILES
-#   Message1.msg
-#   Message2.msg
-# )
-
-## Generate services in the 'srv' folder
-# add_service_files(
-#   FILES
-#   Service1.srv
-#   Service2.srv
-# )
-
-## Generate actions in the 'action' folder
-# add_action_files(
-#   FILES
-#   Action1.action
-#   Action2.action
-# )
-
-## Generate added messages and services with any dependencies listed here
-# generate_messages(
-#   DEPENDENCIES
-#   diagnostic_msgs#   geometry_msgs
-# )
-
-###################################
-## catkin specific configuration ##
-###################################
-## The catkin_package macro generates cmake config files for your package
-## Declare things to be passed to dependent projects
-## INCLUDE_DIRS: uncomment this if you package contains header files
-## LIBRARIES: libraries you create in this project that dependent projects also need
-## CATKIN_DEPENDS: catkin_packages dependent projects also need
-## DEPENDS: system dependencies of this project that dependent projects also need
 catkin_package(
   INCLUDE_DIRS include
   LIBRARIES netft_rdt_driver
-  CATKIN_DEPENDS diagnostic_msgs diagnostic_updater geometry_msgs roscpp
-#  DEPENDS system_lib
+  CATKIN_DEPENDS diagnostic_msgs diagnostic_updater geometry_msgs hardware_interface roscpp rtt_ros
 )
 
-###########
-## Build ##
-###########
-
-## Specify additional locations of header files
-## Your package locations should be listed before other locations
-# include_directories(include)
 include_directories(
  include ${catkin_INCLUDE_DIRS}
 )
 
 ## Declare a cpp library
-add_library(netft_rdt_driver
-   src/netft_rdt_driver.cpp
-)
+add_library(netft_rdt_driver src/netft_rdt_driver.cpp)
+add_library(netft_hardware_interface src/netft_hardware_interface.cpp)
+#~ target_link_libraries(netft_hardware_interface ${catkin_LIBRARIES})
 
 ## Declare a cpp executable
 add_executable(netft_node src/netft_node.cpp)
-
-## Add cmake target dependencies of the executable/library
-## as an example, message headers may need to be generated before nodes
-# add_dependencies(netft_rdt_driver_node netft_rdt_driver_generate_messages_cpp)
 
 ## Specify libraries to link a library or executable target against
 target_link_libraries(netft_node
   netft_rdt_driver ${catkin_LIBRARIES} ${Boost_LIBRARIES}
 )
 
+add_definitions(-DRTT_COMPONENT)
+orocos_component(netft_rtt_controller src/netft_rtt_controller.cpp)
+target_link_libraries(netft_rtt_controller netft_rdt_driver netft_hardware_interface ${catkin_LIBRARIES} ${Boost_LIBRARIES})
+
+orocos_generate_package()
+
 #############
 ## Install ##
 #############
-
-# all install targets should use catkin DESTINATION variables
-# See http://ros.org/doc/api/catkin/html/adv_user_guide/variables.html
-
-## Mark executable scripts (Python etc.) for installation
-## in contrast to setup.py, you can choose the destination
-# install(PROGRAMS
-#   scripts/my_python_script
-#   DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
-# )
 
 ## Mark executables and/or libraries for installation
  install(TARGETS netft_rdt_driver netft_node
@@ -135,30 +56,3 @@ target_link_libraries(netft_node
    LIBRARY DESTINATION ${CATKIN_PACKAGE_LIB_DESTINATION}
    RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
  )
-
-## Mark cpp header files for installation
-# install(DIRECTORY include/${PROJECT_NAME}/
-#   DESTINATION ${CATKIN_PACKAGE_INCLUDE_DESTINATION}
-#   FILES_MATCHING PATTERN "*.h"
-#   PATTERN ".svn" EXCLUDE
-# )
-
-## Mark other files for installation (e.g. launch and bag files, etc.)
-# install(FILES
-#   # myfile1
-#   # myfile2
-#   DESTINATION ${CATKIN_PACKAGE_SHARE_DESTINATION}
-# )
-
-#############
-## Testing ##
-#############
-
-## Add gtest based cpp test target and link libraries
-# catkin_add_gtest(${PROJECT_NAME}-test test/test_netft_rdt_driver.cpp)
-# if(TARGET ${PROJECT_NAME}-test)
-#   target_link_libraries(${PROJECT_NAME}-test ${PROJECT_NAME})
-# endif()
-
-## Add folders to be run by python nosetests
-# catkin_add_nosetests(test)

--- a/netft_rdt_driver/config/force_torque_sensor_controller.yaml
+++ b/netft_rdt_driver/config/force_torque_sensor_controller.yaml
@@ -1,0 +1,3 @@
+force_torque_sensor_controller:
+  type: force_torque_sensor_controller/ForceTorqueSensorController
+  publish_rate: 350

--- a/netft_rdt_driver/config/netft_rrt_controller.ops
+++ b/netft_rdt_driver/config/netft_rrt_controller.ops
@@ -1,0 +1,18 @@
+#!/usr/bin/env deployer-gnulinux
+
+import("rtt_ros")
+import("rtt_rosnode")
+ros.import("netft_rdt_driver")
+
+## Load a NetftRttController component
+loadComponent("NetftRttController","NetftRttController")
+
+## Give it a periodic activity
+setActivity("NetftRttController", 1.0/350.0, HighestPriority, ORO_SCHED_RT)
+
+
+## Configure the RttRosControlExample component
+NetftRttController.configure()
+
+## Start it
+NetftRttController.start()

--- a/netft_rdt_driver/include/netft_rdt_driver/netft_hardware_interface.h
+++ b/netft_rdt_driver/include/netft_rdt_driver/netft_hardware_interface.h
@@ -1,0 +1,99 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, CRI Lab at Nanyang Technological University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Univ of CO, Boulder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Francisco Suarez Ruiz
+   Desc:   ros_control hardware interface layer for netft usign the rdt driver
+*/
+
+#ifndef DENSO_CONTROL__DENSO_HARDWARE_INTERFACE_
+#define DENSO_CONTROL__DENSO_HARDWARE_INTERFACE_
+
+// Boost
+#include <boost/shared_ptr.hpp>
+#include <boost/scoped_ptr.hpp>
+
+// ROS
+#include <ros/ros.h>
+#include <realtime_tools/realtime_publisher.h>
+#include <geometry_msgs/WrenchStamped.h>
+#include <diagnostic_msgs/DiagnosticArray.h>
+#include <diagnostic_updater/DiagnosticStatusWrapper.h>
+
+// ros_control
+#include <controller_manager/controller_manager.h>
+#include <hardware_interface/force_torque_sensor_interface.h>
+
+// netft_rdt_driver
+#include "netft_rdt_driver/netft_rdt_driver.h"
+
+
+namespace netft_rdt_driver
+{
+
+class NetftHardwareInterface : public hardware_interface::RobotHW
+{
+  public:
+    NetftHardwareInterface();
+    bool start();
+    void read(const ros::Time& time, const ros::Duration& period);
+    void write(const ros::Time& time, const ros::Duration& period)  {};
+    void stop()     {};
+    void cleanup()  {};
+
+  private:
+    // State
+    ros::NodeHandle nh_;
+    
+    // netft_rdt_driver
+    std::string   ip_address_;
+    boost::scoped_ptr<netft_rdt_driver::NetFTRDTDriver> netft_;    
+    
+    // Diagnostics
+    boost::scoped_ptr<realtime_tools::RealtimePublisher<diagnostic_msgs::DiagnosticArray> >  diag_publisher_;
+    diagnostic_msgs::DiagnosticArray            diag_array_;
+    diagnostic_updater::DiagnosticStatusWrapper diag_status_;
+    ros::Time last_diag_pub_time_;
+    ros::Duration diag_pub_duration_;
+    
+    // Interfaces
+    hardware_interface::ForceTorqueSensorInterface    ft_sensor_interface_;
+
+    // Data is read from/written to these internal variables
+    double force_[3];
+    double torque_[3];
+};
+
+} // namespace
+
+#endif

--- a/netft_rdt_driver/launch/netft_rrt_controller.launch
+++ b/netft_rdt_driver/launch/netft_rrt_controller.launch
@@ -1,0 +1,21 @@
+<launch>
+  <!-- launch file arguments -->
+  <arg name="ip_address" default="192.168.1.1" />
+  
+  <group ns="ft_sensor">
+    <!-- start netf_rrt_controller (hardware interface) -->
+    <param name="address"  type="string" value="$(arg ip_address)" />
+    <param name="topic"      type="string" value="raw" />
+    <include file="$(find rtt_ros)/launch/deployer.launch">
+      <arg name="DEPLOYER_ARGS" value="-s $(find netft_rdt_driver)/config/netft_rrt_controller.ops"/>
+      <arg name="LOG_LEVEL" value="info"/>
+      <arg name="DEBUG" value="false"/>
+    </include>
+    
+    <!-- spawn force_torque_sensor_controller controller -->
+    <rosparam command="load" file="$(find netft_rdt_driver)/config/force_torque_sensor_controller.yaml" />
+    <node name="force_torque_sensor_controller" pkg="controller_manager" type="spawner" output="screen" args="force_torque_sensor_controller" /> 
+  </group>
+  
+  <node name="rqt_plot_view" pkg="rqt_plot" type="rqt_plot" args="/ft_sensor/raw/wrench/force" />
+</launch>

--- a/netft_rdt_driver/package.xml
+++ b/netft_rdt_driver/package.xml
@@ -4,58 +4,35 @@
   <version>0.0.0</version>
   <description>The netft_rdt_driver package</description>
 
-  <!-- One maintainer tag required, multiple allowed, one person per tag --> 
-  <!-- Example:  -->
-  <!-- <maintainer email="jane.doe@example.com">Jane Doe</maintainer> -->
   <maintainer email="robot.moveit@gmail.com">Sachin Chitta</maintainer>
 
-
-  <!-- One license tag required, multiple allowed, one license per tag -->
-  <!-- Commonly used license strings: -->
-  <!--   BSD, MIT, Boost Software License, GPLv2, GPLv3, LGPLv2.1, LGPLv3 -->
   <license>BSD</license>
 
-
-  <!-- Url tags are optional, but mutiple are allowed, one per tag -->
-  <!-- Optional attribute type can be: website, bugtracker, or repository -->
-  <!-- Example: -->
-  <!-- <url type="website">http://wiki.ros.org/netft_rdt_driver</url> -->
-
-
-  <!-- Author tags are optional, mutiple are allowed, one per tag -->
-  <!-- Authors do not have to be maintianers, but could be -->
-  <!-- Example: -->
   <author email="derek.king@willowgarage.com">Derek King</author>
 
 
-  <!-- The *_depend tags are used to specify dependencies -->
-  <!-- Dependencies can be catkin packages or system dependencies -->
-  <!-- Examples: -->
-  <!-- Use build_depend for packages you need at compile time: -->
-  <!--   <build_depend>message_generation</build_depend> -->
-  <!-- Use buildtool_depend for build tool packages: -->
-  <!--   <buildtool_depend>catkin</buildtool_depend> -->
-  <!-- Use run_depend for packages you need at runtime: -->
-  <!--   <run_depend>message_runtime</run_depend> -->
-  <!-- Use test_depend for packages you need only for testing: -->
-  <!--   <test_depend>gtest</test_depend> -->
   <buildtool_depend>catkin</buildtool_depend>
+  <build_depend>controller_manager</build_depend>
   <build_depend>diagnostic_msgs</build_depend>
   <build_depend>diagnostic_updater</build_depend>
+  <build_depend>force_torque_sensor_controller</build_depend>
   <build_depend>geometry_msgs</build_depend>
+  <build_depend>hardware_interface</build_depend>
   <build_depend>roscpp</build_depend>
+  <build_depend>rtt</build_depend>
+  <build_depend>rtt_ros</build_depend>
+  <build_depend>rtt_rosclock</build_depend>
+  
+  <run_depend>controller_manager</run_depend>
   <run_depend>diagnostic_msgs</run_depend>
   <run_depend>diagnostic_updater</run_depend>
+  <run_depend>force_torque_sensor_controller</run_depend>
   <run_depend>geometry_msgs</run_depend>
+  <run_depend>hardware_interface</run_depend>
   <run_depend>roscpp</run_depend>
+  <run_depend>rtt</run_depend>
+  <run_depend>rtt_rosnode</run_depend>
+  <run_depend>rtt_ros</run_depend>
+  <run_depend>rtt_rosclock</run_depend>
 
-
-  <!-- The export tag contains other, unspecified, tags -->
-  <export>
-    <!-- You can specify that this package is a metapackage here: -->
-    <!-- <metapackage/> -->
-
-    <!-- Other tools can request additional information be placed here -->
-
-  </export>
 </package>

--- a/netft_rdt_driver/src/netft_hardware_interface.cpp
+++ b/netft_rdt_driver/src/netft_hardware_interface.cpp
@@ -1,0 +1,130 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, CRI Lab at Nanyang Technological University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Univ of CO, Boulder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Francisco Suarez Ruiz
+   Desc:   ros_control hardware interface layer for netft usign the rdt driver
+*/
+
+#include <netft_rdt_driver/netft_hardware_interface.h>
+
+
+#define DEFAULT_IP_ADDRESS        "192.168.1.1"
+
+
+namespace netft_rdt_driver
+{
+  NetftHardwareInterface::NetftHardwareInterface()
+  {
+    // Get parameters from the server
+    std::string topic, frame_id;
+    nh_.param(std::string("address"), ip_address_, std::string(DEFAULT_IP_ADDRESS));
+    if (!nh_.hasParam("address"))
+      ROS_WARN_STREAM("Parameter [address] not found, using default: " << ip_address_);
+    
+    nh_.param(std::string("topic"), topic, std::string("raw"));
+    if (!nh_.hasParam("topic"))
+      ROS_WARN_STREAM("Parameter [topic] not found, using default: " << topic);
+    
+    nh_.param(std::string("frame_id"), frame_id, std::string("base_link"));
+    if (!nh_.hasParam("frame_id"))
+      ROS_WARN_STREAM("Parameter [frame_id] not found, using default: " << frame_id);
+
+    // Set initial values
+    force_[0] = 0;
+    force_[1] = 0;
+    force_[2] = 0;
+    torque_[0] = 0;
+    torque_[1] = 0;
+    torque_[2] = 0;
+    
+    // Connect the handle with the hardware interface
+    hardware_interface::ForceTorqueSensorHandle ft_sensor_handle(topic, frame_id, force_, torque_);
+    ft_sensor_interface_.registerHandle(ft_sensor_handle);
+    
+    // Setup Real-Time Publishers
+    diag_publisher_.reset(new realtime_tools::RealtimePublisher<diagnostic_msgs::DiagnosticArray>(nh_, "diagnostics", 2));
+    // Will publish diagnostics every second
+    diag_pub_duration_ = ros::Duration(1.0);
+    diag_array_.status.reserve(1);
+    
+    registerInterface(&ft_sensor_interface_);
+    ROS_INFO("Registered ForceTorqueSensorInterface");
+  }
+  
+  bool NetftHardwareInterface::start()
+  {
+    try {
+      netft_.reset(new netft_rdt_driver::NetFTRDTDriver(ip_address_));
+    }
+    catch (...) {
+      ROS_ERROR("Failed to connect to netft with IP address: %s. Please DOUBLE CHECK the connection with the sensor", ip_address_.c_str());
+      return false;
+    }  
+    return true;
+  }
+  
+  void NetftHardwareInterface::read(const ros::Time& time, const ros::Duration& period)
+  {
+    geometry_msgs::WrenchStamped data;
+    if (netft_->waitForNewData())
+    {
+      netft_->getData(data);
+      force_[0] =   data.wrench.force.x;
+      force_[1] =   data.wrench.force.y;
+      force_[2] =   data.wrench.force.z;
+      torque_[0] =  data.wrench.torque.x;
+      torque_[1] =  data.wrench.torque.y;
+      torque_[2] =  data.wrench.torque.z;
+    }
+    
+    ros::Time current_time(ros::Time::now());
+    if ( (current_time - last_diag_pub_time_) > diag_pub_duration_ )
+    {
+      diag_array_.status.clear();
+      netft_->diagnostics(diag_status_);
+      diag_array_.status.push_back(diag_status_);
+      diag_array_.header.stamp = ros::Time::now();
+      if(diag_publisher_->trylock())
+      {
+        diag_publisher_->msg_.header.stamp = ros::Time::now();
+        diag_publisher_->msg_.status = diag_array_.status;
+        diag_publisher_->unlockAndPublish();
+      }
+      last_diag_pub_time_ = current_time;
+    }
+    
+    
+  }
+
+} // namespace

--- a/netft_rdt_driver/src/netft_rtt_controller.cpp
+++ b/netft_rdt_driver/src/netft_rtt_controller.cpp
@@ -1,0 +1,136 @@
+/*********************************************************************
+ * Software License Agreement (BSD License)
+ *
+ *  Copyright (c) 2015, CRI Lab at Nanyang Technological University
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions
+ *  are met:
+ *
+ *   * Redistributions of source code must retain the above copyright
+ *     notice, this list of conditions and the following disclaimer.
+ *   * Redistributions in binary form must reproduce the above
+ *     copyright notice, this list of conditions and the following
+ *     disclaimer in the documentation and/or other materials provided
+ *     with the distribution.
+ *   * Neither the name of the Univ of CO, Boulder nor the names of its
+ *     contributors may be used to endorse or promote products derived
+ *     from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ *  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ *  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ *  FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ *  COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+ *  INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING,
+ *  BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ *  CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ *  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN
+ *  ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ *  POSSIBILITY OF SUCH DAMAGE.
+ *********************************************************************/
+
+/* Author: Francisco Suarez Ruiz
+   Desc:   rtt controller for netft usign the rdt driver
+*/
+
+#include <rtt/TaskContext.hpp>
+#include <rtt/Port.hpp>
+#include <rtt/Component.hpp>
+
+#include <ros/ros.h>
+#include <ros/callback_queue.h>
+
+#include <rtt_rosclock/rtt_rosclock.h>
+
+#include <boost/thread.hpp>
+
+#include <netft_rdt_driver/netft_hardware_interface.h>
+#include <controller_manager/controller_manager.h>
+
+
+using namespace RTT;
+
+class NetftRttController : public RTT::TaskContext{
+  private:
+
+    // Necessary components to run thread for serving ROS callbacks
+    boost::thread non_rt_ros_queue_thread_;
+    boost::shared_ptr<ros::NodeHandle> non_rt_ros_nh_;
+    ros::CallbackQueue non_rt_ros_queue_;
+
+    // The Netft hardware interface
+    boost::shared_ptr<netft_rdt_driver::NetftHardwareInterface> hw_interface_;
+
+    // The controller manager
+    boost::shared_ptr<controller_manager::ControllerManager> controller_manager_;
+
+    // For saving last update time, so period can be handed to controller manager
+    ros::Time last_update_time_;
+
+  public:
+    NetftRttController(const std::string& name):
+      TaskContext(name)
+    {}
+
+    ~NetftRttController()
+    {}
+
+  private:
+
+    bool configureHook(){
+
+      non_rt_ros_nh_.reset(new ros::NodeHandle(""));
+      non_rt_ros_nh_->setCallbackQueue(&non_rt_ros_queue_);
+      this->non_rt_ros_queue_thread_ = boost::thread( boost::bind( &NetftRttController::serviceNonRtRosQueue,this ) );
+
+      hw_interface_.reset(new netft_rdt_driver::NetftHardwareInterface);
+      hw_interface_->start();
+
+      controller_manager_.reset(new controller_manager::ControllerManager(hw_interface_.get(), *non_rt_ros_nh_));
+
+      last_update_time_ = rtt_rosclock::rtt_now();
+      ROS_INFO("Finished configureHook");
+      return true;
+    }
+
+    void updateHook(){
+
+      // Get current system time (for timestamps of ROS messages)
+      ros::Time now (rtt_rosclock::host_now());
+
+      // Get guaranteed monotonic time for period computation
+      ros::Time now_monotonic(rtt_rosclock::rtt_now());
+
+      ros::Duration period (now_monotonic - last_update_time_);
+      last_update_time_ = now_monotonic;
+
+      hw_interface_->read(now, period);
+      controller_manager_->update(now, period);
+      hw_interface_->write(now, period);
+    }
+    
+    void stopHook()
+    {
+      hw_interface_->stop();
+    }
+
+    void cleanupHook(){
+      hw_interface_->cleanup();
+      non_rt_ros_nh_->shutdown();
+      non_rt_ros_queue_thread_.join();
+    }
+
+    void serviceNonRtRosQueue()
+    {
+      static const double timeout = 0.001;
+
+      while (this->non_rt_ros_nh_->ok()){
+        this->non_rt_ros_queue_.callAvailable(ros::WallDuration(timeout));
+      }
+    }
+
+};
+ORO_CREATE_COMPONENT(NetftRttController)


### PR DESCRIPTION
For applications that require to read from the netft in real-time, this implementation uses a `hardware_interface::ForceTorqueSensorInterface` and a `force_torque_sensor_controller::ForceTorqueSensorController` from `ros_control` along side with OROCOS to achieve such behaviour.
